### PR TITLE
Add `CustomKeyStore` renames and hooks

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-09-27T18:38:14Z"
+  build_date: "2021-09-27T18:54:24Z"
   build_hash: e4d7c2aabd8113176b0662bb3d31751914e2c5e9
   go_version: go1.15.6
   version: v0.14.1
-api_directory_checksum: 40d571fa08b6ae075b8b77ab02f91c01cc0e375a
+api_directory_checksum: 722a67c88acf0a060e82246e2c8bf33816e6cb8e
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: e8872ba28b22ea485729142648f935fec8b4c226
+  file_checksum: d4daf82995db7db0399fc6854397c183b60264d7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/custom_key_store.go
+++ b/apis/v1alpha1/custom_key_store.go
@@ -28,10 +28,6 @@ type CustomKeyStoreSpec struct {
 	// operation.
 	// +kubebuilder:validation:Required
 	CloudHsmClusterID *string `json:"cloudHsmClusterID"`
-	// Specifies a friendly name for the custom key store. The name must be unique
-	// in your AWS account.
-	// +kubebuilder:validation:Required
-	CustomKeyStoreName *string `json:"customKeyStoreName"`
 	// Enter the password of the kmsuser crypto user (CU) account (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
 	// in the specified AWS CloudHSM cluster. AWS KMS logs into the cluster as this
 	// user to manage key material on your behalf.
@@ -42,6 +38,10 @@ type CustomKeyStoreSpec struct {
 	// the password in the AWS CloudHSM cluster.
 	// +kubebuilder:validation:Required
 	KeyStorePassword *string `json:"keyStorePassword"`
+	// Specifies a friendly name for the custom key store. The name must be unique
+	// in your AWS account.
+	// +kubebuilder:validation:Required
+	Name *string `json:"name"`
 	// Enter the content of the trust anchor certificate for the cluster. This is
 	// the content of the customerCA.crt file that you created when you initialized
 	// the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html).

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -23,3 +23,18 @@ resources:
         template_path: hooks/alias/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_pre_set_output:
         template_path: hooks/alias/sdk_read_many_pre_set_output.go.tpl
+  CustomKeyStore:
+    renames:
+      operations:
+        CreateCustomKeyStore:
+          input_fields:
+            CustomKeyStoreName: Name
+        DescribeCustomKeyStores:
+          input_fields:
+            CustomKeyStoreName: Name
+        DeleteCustomKeyStore:
+          input_fields:
+            CustomKeyStoreName: Name
+    hooks:
+      sdk_read_many_post_build_request:
+        template_path: hooks/custom_key_store/sdk_read_many_post_build_request.go.tpl

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -244,13 +244,13 @@ func (in *CustomKeyStoreSpec) DeepCopyInto(out *CustomKeyStoreSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.CustomKeyStoreName != nil {
-		in, out := &in.CustomKeyStoreName, &out.CustomKeyStoreName
+	if in.KeyStorePassword != nil {
+		in, out := &in.KeyStorePassword, &out.KeyStorePassword
 		*out = new(string)
 		**out = **in
 	}
-	if in.KeyStorePassword != nil {
-		in, out := &in.KeyStorePassword, &out.KeyStorePassword
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/kms.services.k8s.aws_customkeystores.yaml
+++ b/config/crd/bases/kms.services.k8s.aws_customkeystores.yaml
@@ -43,10 +43,6 @@ spec:
                   ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
                   operation.
                 type: string
-              customKeyStoreName:
-                description: Specifies a friendly name for the custom key store. The
-                  name must be unique in your AWS account.
-                type: string
               keyStorePassword:
                 description: "Enter the password of the kmsuser crypto user (CU) account
                   (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
@@ -56,6 +52,10 @@ spec:
                   \n This parameter tells AWS KMS the kmsuser account password; it
                   does not change the password in the AWS CloudHSM cluster."
                 type: string
+              name:
+                description: Specifies a friendly name for the custom key store. The
+                  name must be unique in your AWS account.
+                type: string
               trustAnchorCertificate:
                 description: Enter the content of the trust anchor certificate for
                   the cluster. This is the content of the customerCA.crt file that
@@ -63,8 +63,8 @@ spec:
                 type: string
             required:
             - cloudHsmClusterID
-            - customKeyStoreName
             - keyStorePassword
+            - name
             - trustAnchorCertificate
             type: object
           status:

--- a/generator.yaml
+++ b/generator.yaml
@@ -23,3 +23,18 @@ resources:
         template_path: hooks/alias/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_pre_set_output:
         template_path: hooks/alias/sdk_read_many_pre_set_output.go.tpl
+  CustomKeyStore:
+    renames:
+      operations:
+        CreateCustomKeyStore:
+          input_fields:
+            CustomKeyStoreName: Name
+        DescribeCustomKeyStores:
+          input_fields:
+            CustomKeyStoreName: Name
+        DeleteCustomKeyStore:
+          input_fields:
+            CustomKeyStoreName: Name
+    hooks:
+      sdk_read_many_post_build_request:
+        template_path: hooks/custom_key_store/sdk_read_many_post_build_request.go.tpl

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.5.1
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.2

--- a/helm/crds/kms.services.k8s.aws_customkeystores.yaml
+++ b/helm/crds/kms.services.k8s.aws_customkeystores.yaml
@@ -43,10 +43,6 @@ spec:
                   ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
                   operation.
                 type: string
-              customKeyStoreName:
-                description: Specifies a friendly name for the custom key store. The
-                  name must be unique in your AWS account.
-                type: string
               keyStorePassword:
                 description: "Enter the password of the kmsuser crypto user (CU) account
                   (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
@@ -56,6 +52,10 @@ spec:
                   \n This parameter tells AWS KMS the kmsuser account password; it
                   does not change the password in the AWS CloudHSM cluster."
                 type: string
+              name:
+                description: Specifies a friendly name for the custom key store. The
+                  name must be unique in your AWS account.
+                type: string
               trustAnchorCertificate:
                 description: Enter the content of the trust anchor certificate for
                   the cluster. This is the content of the customerCA.crt file that
@@ -63,8 +63,8 @@ spec:
                 type: string
             required:
             - cloudHsmClusterID
-            - customKeyStoreName
             - keyStorePassword
+            - name
             - trustAnchorCertificate
             type: object
           status:

--- a/pkg/resource/custom_key_store/delta.go
+++ b/pkg/resource/custom_key_store/delta.go
@@ -48,18 +48,18 @@ func newResourceDelta(
 			delta.Add("Spec.CloudHsmClusterID", a.ko.Spec.CloudHsmClusterID, b.ko.Spec.CloudHsmClusterID)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.CustomKeyStoreName, b.ko.Spec.CustomKeyStoreName) {
-		delta.Add("Spec.CustomKeyStoreName", a.ko.Spec.CustomKeyStoreName, b.ko.Spec.CustomKeyStoreName)
-	} else if a.ko.Spec.CustomKeyStoreName != nil && b.ko.Spec.CustomKeyStoreName != nil {
-		if *a.ko.Spec.CustomKeyStoreName != *b.ko.Spec.CustomKeyStoreName {
-			delta.Add("Spec.CustomKeyStoreName", a.ko.Spec.CustomKeyStoreName, b.ko.Spec.CustomKeyStoreName)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.KeyStorePassword, b.ko.Spec.KeyStorePassword) {
 		delta.Add("Spec.KeyStorePassword", a.ko.Spec.KeyStorePassword, b.ko.Spec.KeyStorePassword)
 	} else if a.ko.Spec.KeyStorePassword != nil && b.ko.Spec.KeyStorePassword != nil {
 		if *a.ko.Spec.KeyStorePassword != *b.ko.Spec.KeyStorePassword {
 			delta.Add("Spec.KeyStorePassword", a.ko.Spec.KeyStorePassword, b.ko.Spec.KeyStorePassword)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TrustAnchorCertificate, b.ko.Spec.TrustAnchorCertificate) {

--- a/pkg/resource/custom_key_store/resource.go
+++ b/pkg/resource/custom_key_store/resource.go
@@ -95,11 +95,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.CustomKeyStoreName = &identifier.NameOrID
+	r.ko.Status.CustomKeyStoreID = &identifier.NameOrID
 
-	f0, f0ok := identifier.AdditionalKeys["customKeyStoreID"]
-	if f0ok {
-		r.ko.Status.CustomKeyStoreID = &f0
+	f1, f1ok := identifier.AdditionalKeys["name"]
+	if f1ok {
+		r.ko.Spec.Name = &f1
 	}
 
 	return nil

--- a/pkg/resource/custom_key_store/sdk.go
+++ b/pkg/resource/custom_key_store/sdk.go
@@ -63,6 +63,10 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+	// At most one of Store ID and Store Name are allowed
+	if input.CustomKeyStoreId != nil && input.CustomKeyStoreName != nil {
+		input.CustomKeyStoreName = nil
+	}
 	var resp *svcsdk.DescribeCustomKeyStoresOutput
 	resp, err = rm.sdkapi.DescribeCustomKeyStoresWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_MANY", "DescribeCustomKeyStores", err)
@@ -90,9 +94,9 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.CustomKeyStoreID = nil
 		}
 		if elem.CustomKeyStoreName != nil {
-			ko.Spec.CustomKeyStoreName = elem.CustomKeyStoreName
+			ko.Spec.Name = elem.CustomKeyStoreName
 		} else {
-			ko.Spec.CustomKeyStoreName = nil
+			ko.Spec.Name = nil
 		}
 		if elem.TrustAnchorCertificate != nil {
 			ko.Spec.TrustAnchorCertificate = elem.TrustAnchorCertificate
@@ -116,7 +120,7 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return r.ko.Spec.CustomKeyStoreName == nil
+	return r.ko.Status.CustomKeyStoreID == nil
 
 }
 
@@ -130,8 +134,8 @@ func (rm *resourceManager) newListRequestPayload(
 	if r.ko.Status.CustomKeyStoreID != nil {
 		res.SetCustomKeyStoreId(*r.ko.Status.CustomKeyStoreID)
 	}
-	if r.ko.Spec.CustomKeyStoreName != nil {
-		res.SetCustomKeyStoreName(*r.ko.Spec.CustomKeyStoreName)
+	if r.ko.Spec.Name != nil {
+		res.SetCustomKeyStoreName(*r.ko.Spec.Name)
 	}
 
 	return res, nil
@@ -184,8 +188,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.CloudHsmClusterID != nil {
 		res.SetCloudHsmClusterId(*r.ko.Spec.CloudHsmClusterID)
 	}
-	if r.ko.Spec.CustomKeyStoreName != nil {
-		res.SetCustomKeyStoreName(*r.ko.Spec.CustomKeyStoreName)
+	if r.ko.Spec.Name != nil {
+		res.SetCustomKeyStoreName(*r.ko.Spec.Name)
 	}
 	if r.ko.Spec.KeyStorePassword != nil {
 		res.SetKeyStorePassword(*r.ko.Spec.KeyStorePassword)

--- a/templates/hooks/custom_key_store/sdk_read_many_post_build_request.go.tpl
+++ b/templates/hooks/custom_key_store/sdk_read_many_post_build_request.go.tpl
@@ -1,0 +1,4 @@
+// At most one of Store ID and Store Name are allowed
+if input.CustomKeyStoreId != nil && input.CustomKeyStoreName != nil {
+  input.CustomKeyStoreName = nil
+}


### PR DESCRIPTION
Rebased on top of https://github.com/aws-controllers-k8s/kms-controller/pull/5

Description of changes:
- Rename `CustomKeyStoreName` to `Name` to reduce rendundancy
- Add hook for `ReadMany` limitation on number of fields in input shape
- Add tests for `CustomKeyStore`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
