### PR TITLE
Move `Alias` primary key to `Name`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-22T22:26:26Z"
+  build_date: "2023-03-23T17:58:11Z"
   build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
-  go_version: go1.19
+  go_version: go1.19.1
   version: v0.25.0
 api_directory_checksum: 70eb6bda460cfa4eda159f3e887696468dabf7a2
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 1c0b28a47418369cfa6e2f6c9eda9e98919d59f0
+  file_checksum: c50c82ea4d670f242a21232604a24a9d83fbcee8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,8 +1,9 @@
 resources:
   Alias:
     fields:
-      TargetKeyId:
+      Name:
         is_primary_key: true
+      TargetKeyId:
         is_required: true
         from:
           operation: CreateAlias

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,8 +1,9 @@
 resources:
   Alias:
     fields:
-      TargetKeyId:
+      Name:
         is_primary_key: true
+      TargetKeyId:
         is_required: true
         from:
           operation: CreateAlias

--- a/pkg/resource/alias/resource.go
+++ b/pkg/resource/alias/resource.go
@@ -88,7 +88,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.TargetKeyID = &identifier.NameOrID
+	r.ko.Spec.Name = &identifier.NameOrID
 
 	return nil
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1746

Description of changes:
Alias `Name` is the primary key lookup used inside `sdkFind` to determine which of the objects returned by `ListAliases` matches the spec. This pull request moves the `is_primary_key: true` attribute from `TargetKeyId` to `Name`, so that the resource can be adopted by using `alias/<alias-name>` as the `nameOrID` field. 

**Note:** The `nameOrID` field must begin with `alias/` since all alias names returned by the `ListAliases` API are prepended with that prefix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
