### PR TITLE
convert managed policy to inline, add ScheduleKeyDeletion permission

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateAlias",
+                "kms:CreateKey",
+                "kms:DeleteAlias",
+                "kms:Describe*",
+                "kms:GenerateRandom",
+                "kms:Get*",
+                "kms:List*",
+                "kms:ScheduleKeyDeletion",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "iam:ListGroups",
+                "iam:ListRoles",
+                "iam:ListUsers"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/recommended-policy-arn
+++ b/config/iam/recommended-policy-arn
@@ -1,1 +1,0 @@
-arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser


### PR DESCRIPTION
Description of changes:
- convert `arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser` into inline policy
- add ScheduleKeyDeletion into inline policy


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
