### PR TITLE
add permission for multi-regions key

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -16,7 +16,8 @@
                 "kms:UntagResource",
                 "iam:ListGroups",
                 "iam:ListRoles",
-                "iam:ListUsers"
+                "iam:ListUsers",
+                "iam:CreateServiceLinkedRole"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Description of changes:

add permission to create multiple region key

ref: 
      https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-auth.html
      Service-linked role — Principals who create multi-Region primary keys must have iam:CreateServiceLinkedRole permission.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
