### PR TITLE
fix(helm): Ensure non-default service account name works in installScope 'namespace'

### DIFF
--- a/helm/templates/caches-role-binding.yaml
+++ b/helm/templates/caches-role-binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: ack-namespaces-cache-kms-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-kms-controller
+  name: {{ include "ack-kms-controller.service-account.name" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,5 +22,5 @@ roleRef:
   name: ack-configmaps-cache-kms-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-kms-controller
+  name: {{ include "ack-kms-controller.service-account.name" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: This change ensures that the required `ClusterRoleBinding` and `RoleBinding` objects apply to a `ServiceAccount` with custom name when running with `installScope: namespace`.

Error seen with custom service account name:

```
pkg/mod/k8s.io/client-go@v0.30.1/tools/cache/reflector.go:232: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kms-controller:kms-controller" cannot list resource "configmaps" in API group "" in the namespace "kms-controller"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.