### PR TITLE
remove getImmutableFieldChanges references from hooks

### DIFF
--- a/pkg/resource/key/hooks.go
+++ b/pkg/resource/key/hooks.go
@@ -15,12 +15,9 @@ package key
 
 import (
 	"context"
-	"fmt"
 	"strconv"
-	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/kms"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,11 +63,6 @@ func (rm *resourceManager) customUpdate(
 	defer func() {
 		exit(err)
 	}()
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s",
-			strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 	updatedRes := rm.concreteResource(desired.DeepCopy())
 	updatedRes.SetStatus(latest)
 

--- a/test/e2e/tests/test_key.py
+++ b/test/e2e/tests/test_key.py
@@ -244,18 +244,6 @@ class TestKey:
 
         key_policy = kms_client.get_key_policy(KeyId=key_id, PolicyName='default')
         assert 'updated-key-policy' in key_policy['Policy']
-
-        # updating description should set terminal condition on the resource
-        # because only tags and policy related fields can be updated on the Key
-        # resource
-        updates = {
-            "spec": {
-                "description": 'only policy and tags update are supported'
-            }
-        }
-        k8s.patch_custom_resource(ref, updates)
-        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.Terminal", "True", wait_periods=10)
     
     def test_create_with_rotation(self, kms_client, key_with_rotation):
         (ref, cr) = key_with_rotation


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability
Remove immutability tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
