### PR TITLE
Add kms:PutPolicy to recommended policy

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -15,6 +15,7 @@
                 "kms:TagResource",
                 "kms:UntagResource",
                 "kms:EnableKeyRotation",
+                "kms:PutKeyPolicy",
                 "iam:ListGroups",
                 "iam:ListRoles",
                 "iam:ListUsers",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Issue #, if available:

Description of changes:
fixes issue when adding policy to keys
```
    Reason:                operation error KMS: PutKeyPolicy, https response error StatusCode: 400, RequestID: 1f1f1f1f-ca76-4d28-8238-1f1f1f1f1f1f1f, api error AccessDeniedException: User: arn:aws:sts::xxxxxxxxx:assumed-role/ack-kms-20250110xxxxxxxxx/yyyyyyy is not authorized to perform: kms:PutKeyPolicy on resource: arn:aws:kms:us-west-x:xxxxxx:key/2s2s2s2s2s-1edd-44a6-9ad1-3d3d3d3d3d3d3d because no identity-based policy allows the kms:PutKeyPolicy action
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
