### PR TITLE
feat: Allow users to create alias without defining name prefix

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-03-28T19:41:06Z"
+  build_date: "2025-04-02T19:17:04Z"
   build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
   go_version: go1.24.1
   version: v0.44.0
@@ -7,7 +7,7 @@ api_directory_checksum: d4bcac73647daf9aa536c9d87757f98e9f0d99ba
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: b1b00ca490a74a665051cc37197f318ab5920f15
+  file_checksum: f5076f21da84e2f0cfb1d2223af672b469ab9c08
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -23,8 +23,14 @@ resources:
           input_fields:
             AliasName: Name
     hooks:
+      sdk_create_post_build_request:
+        template_path: hooks/alias/sdk_create_post_build_request.go.tpl
       sdk_read_many_pre_set_output:
         template_path: hooks/alias/sdk_read_many_pre_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/alias/sdk_update_post_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/alias/sdk_delete_post_build_request.go.tpl
     tags:
       ignore: true
   Key:

--- a/generator.yaml
+++ b/generator.yaml
@@ -23,8 +23,14 @@ resources:
           input_fields:
             AliasName: Name
     hooks:
+      sdk_create_post_build_request:
+        template_path: hooks/alias/sdk_create_post_build_request.go.tpl
       sdk_read_many_pre_set_output:
         template_path: hooks/alias/sdk_read_many_pre_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/alias/sdk_update_post_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/alias/sdk_delete_post_build_request.go.tpl
     tags:
       ignore: true
   Key:

--- a/pkg/resource/alias/hooks.go
+++ b/pkg/resource/alias/hooks.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package alias
+
+import (
+	"strings"
+)
+
+const AliasPrefix = "alias/"
+
+// ensureAliasName accepts the name of an Alias, and
+// ensures it has the alias prefix. If it does not
+// it returns a name with the prefix
+func ensureAliasName(name *string) *string {
+	if name == nil {
+		return nil
+	}
+
+	nameVal := *name
+	// alias/ should be the prefix of the name
+	if !strings.HasPrefix(nameVal, AliasPrefix) {
+		nameVal = AliasPrefix + nameVal
+	}
+	return &nameVal
+}

--- a/pkg/resource/alias/hooks_test.go
+++ b/pkg/resource/alias/hooks_test.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package alias
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureAliasName(t *testing.T) {
+	tests := []struct {
+		name     string
+		provided *string
+		expected *string
+	}{
+		{
+			name:     "alias without prefix",
+			provided: stringPtr("foo"),
+			expected: stringPtr("alias/foo"),
+		},
+		{
+			name:     "alias with prefix",
+			provided: stringPtr("alias/foo"),
+			expected: stringPtr("alias/foo"),
+		},
+		{
+			// This one should not be 
+			// expected either since
+			// aliasName is required
+			// field
+			name:     "nil alias",
+			provided: nil,
+			expected: nil,
+		},
+		{
+			// This one should be an error, 
+			// but expected to be handled by
+			// the AWS API
+			name:     "just the prefix",
+			provided: stringPtr("alias/"),
+			expected: stringPtr("alias/"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ensureAliasName(tt.provided)
+			if actual != nil {
+				assert.NotNil(t, tt.expected)
+				assert.Equal(t, *tt.expected, *actual)
+			} else {
+				assert.Nil(t, tt.expected)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+

--- a/pkg/resource/alias/sdk.go
+++ b/pkg/resource/alias/sdk.go
@@ -104,14 +104,15 @@ func (rm *resourceManager) sdkFind(
 		}
 		aliases = append(aliases, resp.Aliases...)
 	}
+	aliasName := ensureAliasName(r.ko.Spec.Name)
 	// Filter resulting aliases, matching only the one with the name in the spec
 	matchingAliases := []svcsdktypes.AliasListEntry{}
 	for _, elem := range aliases {
-		if elem.AliasName == nil || r.ko.Spec.Name == nil {
+		if elem.AliasName == nil || aliasName == nil {
 			continue
 		}
 
-		if *elem.AliasName == *r.ko.Spec.Name {
+		if *elem.AliasName == *aliasName {
 			matchingAliases = append(matchingAliases, elem)
 		}
 	}
@@ -177,6 +178,7 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+	input.AliasName = ensureAliasName(input.AliasName)
 
 	var resp *svcsdk.CreateAliasOutput
 	_ = resp
@@ -228,6 +230,7 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
+	input.AliasName = ensureAliasName(input.AliasName)
 
 	var resp *svcsdk.UpdateAliasOutput
 	_ = resp
@@ -277,6 +280,8 @@ func (rm *resourceManager) sdkDelete(
 	if err != nil {
 		return nil, err
 	}
+	input.AliasName = ensureAliasName(input.AliasName)
+
 	var resp *svcsdk.DeleteAliasOutput
 	_ = resp
 	resp, err = rm.sdkapi.DeleteAlias(ctx, input)

--- a/templates/hooks/alias/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/alias/sdk_create_post_build_request.go.tpl
@@ -1,0 +1,1 @@
+    input.AliasName = ensureAliasName(input.AliasName)

--- a/templates/hooks/alias/sdk_delete_post_build_request.go.tpl
+++ b/templates/hooks/alias/sdk_delete_post_build_request.go.tpl
@@ -1,0 +1,1 @@
+    input.AliasName = ensureAliasName(input.AliasName)

--- a/templates/hooks/alias/sdk_read_many_pre_set_output.go.tpl
+++ b/templates/hooks/alias/sdk_read_many_pre_set_output.go.tpl
@@ -14,15 +14,16 @@
 		}
 		aliases = append(aliases, resp.Aliases...)
 	}
+	aliasName := ensureAliasName(r.ko.Spec.Name)
 	// Filter resulting aliases, matching only the one with the name in the spec
 	matchingAliases := []svcsdktypes.AliasListEntry{}
 	for _, elem := range aliases {
-	  if elem.AliasName == nil || r.ko.Spec.Name == nil {
-		continue
-	  }
+		if elem.AliasName == nil || aliasName == nil {
+			continue
+		}
 
-	  if *elem.AliasName == *r.ko.Spec.Name {
-		matchingAliases = append(matchingAliases, elem)
-	  }
+		if *elem.AliasName == *aliasName {
+			matchingAliases = append(matchingAliases, elem)
+		}
 	}
 	resp.Aliases = matchingAliases

--- a/templates/hooks/alias/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/alias/sdk_update_post_build_request.go.tpl
@@ -1,0 +1,1 @@
+    input.AliasName = ensureAliasName(input.AliasName)

--- a/test/e2e/resources/alias_simple_no_prefix.yaml
+++ b/test/e2e/resources/alias_simple_no_prefix.yaml
@@ -1,0 +1,7 @@
+apiVersion: kms.services.k8s.aws/v1alpha1
+kind: Alias
+metadata:
+  name: $ALIAS_NAME
+spec:
+  name: $ALIAS_NAME
+  targetKeyID: $TARGET_KEY_ID


### PR DESCRIPTION
Issue [#1878](https://github.com/aws-controllers-k8s/community/issues/1878)

Description of changes:
Currently, if a user provides an alias name without providing its 
prefix, the API rejects that request

This change allows users to provide an alias name without the 
prefix and the controller will add one before calling the API. It also 
keeps the backwards compatibility to have a no action if user already 
provides the prefix


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
