### PR TITLE
tests: Ready condition rename for kms-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T17:14:56Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:43:43Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: d7d7a0e4a96da2505f9eb6d591444f6381f5d52e
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/kms.services.k8s.aws_aliases.yaml
+++ b/config/crd/bases/kms.services.k8s.aws_aliases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: aliases.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/config/crd/bases/kms.services.k8s.aws_grants.yaml
+++ b/config/crd/bases/kms.services.k8s.aws_grants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: grants.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/config/crd/bases/kms.services.k8s.aws_keys.yaml
+++ b/config/crd/bases/kms.services.k8s.aws_keys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: keys.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/kms.services.k8s.aws_aliases.yaml
+++ b/helm/crds/kms.services.k8s.aws_aliases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: aliases.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/helm/crds/kms.services.k8s.aws_grants.yaml
+++ b/helm/crds/kms.services.k8s.aws_grants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: grants.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/helm/crds/kms.services.k8s.aws_keys.yaml
+++ b/helm/crds/kms.services.k8s.aws_keys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: keys.kms.services.k8s.aws
 spec:
   group: kms.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/alias/references.go
+++ b/pkg/resource/alias/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -132,8 +133,9 @@ func getReferencedResourceState_Key(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Key",
 				namespace, name)
@@ -144,14 +146,14 @@ func getReferencedResourceState_Key(
 			"Key",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Key",
 			namespace, name)

--- a/pkg/resource/grant/references.go
+++ b/pkg/resource/grant/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -132,8 +133,9 @@ func getReferencedResourceState_Key(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Key",
 				namespace, name)
@@ -144,14 +146,14 @@ func getReferencedResourceState_Key(
 			"Key",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Key",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -20,7 +20,7 @@ import pytest
 import time
 
 from acktest.k8s import resource as k8s
-from acktest.k8s.condition import CONDITION_TYPE_RESOURCE_SYNCED, CONDITION_TYPE_REFERENCES_RESOLVED
+from acktest.k8s.condition import CONDITION_TYPE_READY, CONDITION_TYPE_REFERENCES_RESOLVED
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_kms_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -128,7 +128,7 @@ class TestAlias:
         (ref, cr) = simple_alias
         another_key_id = another_key['KeyMetadata']['KeyId']
 
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, CONDITION_TYPE_READY, "True", wait_periods=10)
         assert 'arn' in cr['status']['ackResourceMetadata']
         alias_arn = cr['status']['ackResourceMetadata']['arn']
 
@@ -141,7 +141,7 @@ class TestAlias:
 
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, CONDITION_TYPE_READY, "True", wait_periods=10)
         alias = kms_validator.get_alias(arn=alias_arn, target_key_id=another_key_id)
         assert alias is not None, f"Alias should not be None for key id {another_key_id}"
 
@@ -153,7 +153,7 @@ class TestAlias:
     def test_create_delete_alias_no_prefix(self, simple_alias_no_prefix, another_key):
         (ref, cr) = simple_alias_no_prefix
 
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, CONDITION_TYPE_READY, "True", wait_periods=10)
         assert 'arn' in cr['status']['ackResourceMetadata']
         alias_arn = cr['status']['ackResourceMetadata']['arn']
 
@@ -206,8 +206,8 @@ class TestAlias:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(key_ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
-        assert k8s.wait_on_condition(alias_ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+        assert k8s.wait_on_condition(key_ref, CONDITION_TYPE_READY, "True", wait_periods=10)
+        assert k8s.wait_on_condition(alias_ref, CONDITION_TYPE_READY, "True", wait_periods=10)
 
         assert k8s.wait_on_condition(alias_ref, CONDITION_TYPE_REFERENCES_RESOLVED, "True", wait_periods=10)
 

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -209,7 +209,7 @@ class TestAlias:
         assert k8s.wait_on_condition(key_ref, CONDITION_TYPE_READY, "True", wait_periods=10)
         assert k8s.wait_on_condition(alias_ref, CONDITION_TYPE_READY, "True", wait_periods=10)
 
-        assert k8s.wait_on_condition(alias_ref, CONDITION_TYPE_REFERENCES_RESOLVED, "True", wait_periods=10)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         alias_cr = k8s.get_resource(alias_ref)
         alias_arn = alias_cr['status']['ackResourceMetadata']['arn']

--- a/test/e2e/tests/test_grant.py
+++ b/test/e2e/tests/test_grant.py
@@ -19,8 +19,7 @@ import logging
 import pytest
 import time
 
-from acktest.k8s import resource as k8s
-from acktest.k8s.condition import CONDITION_TYPE_READY, CONDITION_TYPE_TERMINAL
+from acktest.k8s import resource as k8s, condition
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_kms_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -86,7 +85,7 @@ class TestGrant:
         (ref, cr) = simple_grant
         key_id = simple_key['KeyMetadata']['KeyId']
 
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_READY, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, condition.CONDITION_TYPE_READY, "True", wait_periods=10)
         assert 'grantID' in cr['status']
         grant_id = cr['status']['grantID']
 
@@ -104,7 +103,8 @@ class TestGrant:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
         # Grant resource does not support update operation, so the terminal condition should be set
         # on the resource
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_TERMINAL, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, condition.CONDITION_TYPE_READY, "False", wait_periods=10)
+        condition.assert_terminal(ref)
 
         _, deleted = k8s.delete_custom_resource(ref, DELETE_WAIT_PERIODS, DELETE_WAIT_PERIOD_LENGTH_SECONDS)
         assert deleted

--- a/test/e2e/tests/test_grant.py
+++ b/test/e2e/tests/test_grant.py
@@ -20,7 +20,7 @@ import pytest
 import time
 
 from acktest.k8s import resource as k8s
-from acktest.k8s.condition import CONDITION_TYPE_RESOURCE_SYNCED, CONDITION_TYPE_TERMINAL
+from acktest.k8s.condition import CONDITION_TYPE_READY, CONDITION_TYPE_TERMINAL
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_kms_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -86,7 +86,7 @@ class TestGrant:
         (ref, cr) = simple_grant
         key_id = simple_key['KeyMetadata']['KeyId']
 
-        assert k8s.wait_on_condition(ref, CONDITION_TYPE_RESOURCE_SYNCED, "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, CONDITION_TYPE_READY, "True", wait_periods=10)
         assert 'grantID' in cr['status']
         grant_id = cr['status']['grantID']
 

--- a/test/e2e/tests/test_key.py
+++ b/test/e2e/tests/test_key.py
@@ -240,7 +240,7 @@ class TestKey:
 
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
         key_policy = kms_client.get_key_policy(KeyId=key_id, PolicyName='default')
         assert 'updated-key-policy' in key_policy['Policy']
@@ -260,7 +260,7 @@ class TestKey:
 
     def test_update_tags(self, kms_client, simple_key):
         (ref, cr) = simple_key
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
         assert 'keyID' in cr['status']
         key_id = cr['status']['keyID']
@@ -285,7 +285,7 @@ class TestKey:
                 }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
         key_tags = kms_client.list_resource_tags(KeyId=key_id)['Tags']
         tags.assert_ack_system_tags(
@@ -317,7 +317,7 @@ class TestKey:
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
         key_tags = kms_client.list_resource_tags(KeyId=key_id)['Tags']
         tags.assert_ack_system_tags(
@@ -349,7 +349,7 @@ class TestKey:
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
         key_tags = kms_client.list_resource_tags(KeyId=key_id)['Tags']
         tags.assert_ack_system_tags(


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._