### PR TITLE
Mark Key.Policy as is_iam_policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:50:23Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-06-19T03:02:24Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
+  go_version: go1.26.0
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: d7d7a0e4a96da2505f9eb6d591444f6381f5d52e
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: f5076f21da84e2f0cfb1d2223af672b469ab9c08
+  file_checksum: dbe42b907b534a1267eb675cc3157f8e3a89a425
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,8 @@ resources:
       ignore: true
   Key:
     fields:
+      Policy:
+        is_iam_policy: true
       Origin:
         is_immutable: true
       MultiRegion:

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,8 @@ resources:
       ignore: true
   Key:
     fields:
+      Policy:
+        is_iam_policy: true
       Origin:
         is_immutable: true
       MultiRegion:

--- a/pkg/resource/key/delta.go
+++ b/pkg/resource/key/delta.go
@@ -100,7 +100,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
 		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
-		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds is_iam_policy: true annotation to Key.Policy field in generator.yaml.

## Problem

The KMS Key.Policy field accepts an IAM key policy document (JSON). Without the is_iam_policy annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_iam_policy: true to Key.Policy in generator.yaml
- Regenerated controller code - delta.go now uses IAMPolicyDocumentEqual for semantic comparison

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test (key_with_policy.yaml fixture) already exercises the policy field

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.